### PR TITLE
Add local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Install globally:
 npm install -g @openai/codex
 ```
 
-Next, set your OpenAI API key as an environment variable:
+Next, set your OpenAI API key as an environment variable (skip this when using a local server):
 
 ```shell
 export OPENAI_API_KEY="your-api-key-here"
@@ -90,6 +90,18 @@ export OPENAI_API_KEY="your-api-key-here"
 > ```
 >
 > The CLI will automatically load variables from `.env` (via `dotenv/config`).
+
+If you're running a local OpenAI-compatible server you can skip the API key and
+use the `--local` flag or specify a custom endpoint with `--api-base`:
+
+```shell
+codex --local
+# or
+codex --api-base http://localhost:11434/v1
+```
+
+Alternatively set `CODEX_API_BASE` in your environment to configure the default
+endpoint.
 
 <details>
 <summary><strong>Use <code>--provider</code> to use other models</strong></summary>
@@ -119,6 +131,8 @@ export OPENAI_API_KEY="your-api-key-here"
 > ```shell
 > export <provider>_BASE_URL="https://your-provider-api-base-url"
 > ```
+
+> When running a local server you can use `CODEX_API_BASE` with the `--local` flag instead.
 
 </details>
 <br />
@@ -222,7 +236,7 @@ The hardening mechanism Codex uses depends on your OS:
 | `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
 
-Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
+Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, `--notify`, `--local`, and `--api-base`.
 
 ---
 

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1251,7 +1251,7 @@ export class AgentLoop {
               this.onLoading(false);
               return;
             }
-            // Handle OpenAI API quota errors
+            // Handle API quota errors from remote providers
             if (
               err instanceof Error &&
               (err as { code?: string }).code === "insufficient_quota"
@@ -1263,7 +1263,7 @@ export class AgentLoop {
                 content: [
                   {
                     type: "input_text",
-                    text: `\u26a0 Insufficient quota: ${err instanceof Error && err.message ? err.message.trim() : "No remaining quota."} Manage or purchase credits at https://platform.openai.com/account/billing.`,
+                    text: `\u26a0 Insufficient quota: ${err instanceof Error && err.message ? err.message.trim() : "No remaining quota."}`,
                   },
                 ],
               });

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -117,13 +117,26 @@ export function getApiKey(provider: string = "openai"): string | undefined {
     if (providerInfo.name === "Ollama") {
       return process.env[providerInfo.envKey] ?? "dummy";
     }
-    return process.env[providerInfo.envKey];
+    const key = process.env[providerInfo.envKey];
+    if (key) {
+      return key;
+    }
+    const base = getBaseUrl(provider);
+    if (base && /^(https?:\/\/)?(localhost|127\.0\.0\.1)/.test(base)) {
+      return "dummy";
+    }
+    return undefined;
   }
 
   // Checking `PROVIDER_API_KEY` feels more intuitive with a custom provider.
   const customApiKey = process.env[`${provider.toUpperCase()}_API_KEY`];
   if (customApiKey) {
     return customApiKey;
+  }
+
+  const base = getBaseUrl(provider);
+  if (base && /^(https?:\/\/)?(localhost|127\.0\.0\.1)/.test(base)) {
+    return "dummy";
   }
 
   // If the provider not found in the providers list and `OPENAI_API_KEY` is set, use it


### PR DESCRIPTION
## Summary
- allow `--api-base` flag and `--local` mode
- default to `http://localhost:11434/v1` for local LLMs
- skip login and API key checks when using local endpoint
- relax quota error text
- update docs for local usage

## Testing
- `pnpm -r test` *(fails: vitest not found)*
- `pnpm -r lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c849b408329b8dc5625e905c23f