### PR TITLE
Fix README for lmstudio-agent path

### DIFF
--- a/packages/lmstudio-agent/README.md
+++ b/packages/lmstudio-agent/README.md
@@ -9,6 +9,9 @@ pnpm install --global ./packages/lmstudio-agent
 lmstudio-agent "Descreva sua tarefa"
 ```
 
+Se receber `lmstudio-agent: command not found`, verifique se o diretório de binários globais do pnpm está no seu `PATH`.
+Execute `pnpm setup` ou adicione `~/.local/share/pnpm` (ou o caminho equivalente no seu sistema) à variável `PATH`.
+
 O agente comunica‑se com o endpoint OpenAI compatível do LM Studio (por padrão `http://localhost:1234/v1`).
 
 Variáveis de ambiente:


### PR DESCRIPTION
## Summary
- mention how to fix `lmstudio-agent` not found by adding pnpm's global bin directory to PATH

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a68f965d88329936db9594699e540